### PR TITLE
Updates for new scikit-learn and python 3.11

### DIFF
--- a/src/lemon/_lemon.py
+++ b/src/lemon/_lemon.py
@@ -187,7 +187,7 @@ class _InterpretableSamples:
 
         categories = [[0, 1, 2]] * self._X.shape[1] if self.perturb_injection else [[0, 1]] * self._X.shape[1]
         self._X_dummy = sklearn.preprocessing.OneHotEncoder(
-            categories=categories, drop="first", sparse=False
+            categories=categories, drop="first", sparse_output=False
         ).fit_transform(self._X)
 
         self.distances = np.array(self.distances)

--- a/src/lemon/_lemon_utils.py
+++ b/src/lemon/_lemon_utils.py
@@ -268,7 +268,7 @@ def perturb_record_pair(
 
     if random_state is None:
         random_state = np.random.default_rng()
-    std_random = random.Random(random_state.integers(1e9))
+    std_random = random.Random(int(random_state.integers(1e9)))
 
     relevant_target_attrs = {}
     for source, attr in record_pair.columns.to_list():
@@ -334,7 +334,7 @@ def perturb_record_pair(
 
         if injections:
             max_injection_sampling = 0
-            for (source, attr, attr_or_val, j) in injections:
+            for source, attr, attr_or_val, j in injections:
                 target_source = "a" if source == "b" else "b"
                 target_attrs = relevant_target_attrs[(source, attr, attr_or_val)]
                 suggested_injection_sampling = 0


### PR DESCRIPTION
Hi,
I was trying to run lemon using Python 3.11.2 and scikit-learn 1.5.2. I ran into some issues due to API changes. Namely, in the OneHotEncoder of scikit-learn the ["sparse" keyword argument was renamed to "sparse_output" in 1.2](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html), while in Python 3.11 the Random object now [requires very specific types](https://github.com/petl-developers/petl/issues/657), so I had to cast np.int64 to int().